### PR TITLE
Update amazon.py to fix incorrect variable reference

### DIFF
--- a/src/benchmarks/semistruct/amazon.py
+++ b/src/benchmarks/semistruct/amazon.py
@@ -522,7 +522,7 @@ class AmazonSemiStruct(SemiStructureKB):
                 asin = df_i['asin']
                 idx = self.asin2id[asin]
                 node_info[idx][name].append(
-                    df_row_to_dict(df_i, colunm_names=review_columns \
+                    df_row_to_dict(df_i, colunm_names=self.review_columns \
                                    if name == 'review' else self.qa_columns))
         import pdb; pdb.set_trace()
         return node_info


### PR DESCRIPTION
Updated the code to correctly reference `self.review_columns` instead of the non-existent `review_columns` variable.  Fixes #3 