### PR TITLE
Add support for batch-wise evaluation and metric computation on cuda

### DIFF
--- a/eval.py
+++ b/eval.py
@@ -27,6 +27,8 @@ def parse_args():
 
     # Evaluation settings
     parser.add_argument("--test_ratio", type=float, default=1.0)
+    parser.add_argument("--batch_size", type=int, default=256)
+    parser.add_argument("--device", type=str, default='cuda')
 
     # MultiVSS specific settings
     parser.add_argument("--chunk_size", type=int, default=None)
@@ -106,31 +108,49 @@ if __name__ == "__main__":
         existing_idx = eval_csv["idx"].tolist()
 
     indices = split_idx[args.split].tolist()
-
-    for idx in tqdm(indices):
-        if idx in existing_idx:
-            continue
-        query, query_id, answer_ids, meta_info = qa_dataset[idx]
-        pred_dict = model.forward(query, query_id)
-
-        answer_ids = torch.LongTensor(answer_ids)
-        result = model.evaluate(pred_dict, answer_ids, metrics=eval_metrics)
-
-        result["idx"], result["query_id"] = idx, query_id
-        result["pred_rank"] = torch.LongTensor(list(pred_dict.keys()))[
-            torch.argsort(torch.tensor(list(pred_dict.values())), descending=True)[
-                :args.save_topk
-            ]
-        ].tolist()
-
-        eval_csv = pd.concat([eval_csv, pd.DataFrame([result])], ignore_index=True)
-
-        if args.save_pred:
-            eval_csv.to_csv(eval_csv_path, index=False)
-        for metric in eval_metrics:
-            print(
-                f"{metric}: {np.mean(eval_csv[eval_csv['idx'].isin(indices)][metric])}"
+    
+    if args.batch_size > 0 and args.model=='VSS':
+        for batch_idx in tqdm(range(0, len(indices), args.batch_size or len(indices))):
+            batch_indices = [idx for idx in indices[batch_idx : min(batch_idx + args.batch_size, len(indices))] if idx not in existing_idx]
+            if len(batch_indices) == 0:
+                continue
+            queries, query_ids, answer_ids, meta_infos = zip(
+                *[qa_dataset[idx] for idx in batch_indices]
             )
+            pred_ids, pred = model.forward(queries, query_ids)
+            
+            answer_ids = [torch.LongTensor(answer_id) for answer_id in answer_ids]
+            results = model.evaluate_batch(pred_ids, pred, answer_ids, metrics=eval_metrics)
+
+            for i, result in enumerate(results):
+                result["idx"], result["query_id"] = batch_indices[i], query_ids[i]
+                result["pred_rank"] = pred_ids[torch.argsort(pred[:,i], descending=True)[:args.save_topk]].tolist()
+                eval_csv = pd.concat([eval_csv, pd.DataFrame([result])], ignore_index=True)
+    else:
+        for idx in tqdm(indices):
+            if idx in existing_idx:
+                continue
+            query, query_id, answer_ids, meta_info = qa_dataset[idx]
+            pred_dict = model.forward(query, query_id)
+
+            answer_ids = torch.LongTensor(answer_ids)
+            result = model.evaluate(pred_dict, answer_ids, metrics=eval_metrics)
+
+            result["idx"], result["query_id"] = idx, query_id
+            result["pred_rank"] = torch.LongTensor(list(pred_dict.keys()))[
+                torch.argsort(torch.tensor(list(pred_dict.values())), descending=True)[
+                    :args.save_topk
+                ]
+            ].tolist()
+
+            eval_csv = pd.concat([eval_csv, pd.DataFrame([result])], ignore_index=True)
+
+            if args.save_pred:
+                eval_csv.to_csv(eval_csv_path, index=False)
+            for metric in eval_metrics:
+                print(
+                    f"{metric}: {np.mean(eval_csv[eval_csv['idx'].isin(indices)][metric])}"
+                )
     if args.save_pred:
         eval_csv.to_csv(eval_csv_path, index=False)
     final_metrics = (

--- a/models/__init__.py
+++ b/models/__init__.py
@@ -9,7 +9,8 @@ def get_model(args, kb):
             kb,
             emb_model=args.emb_model,
             query_emb_dir=args.query_emb_dir, 
-            candidates_emb_dir=args.node_emb_dir
+            candidates_emb_dir=args.node_emb_dir,
+            device=args.device
         )
     if model_name == 'MultiVSS':
         return MultiVSS(


### PR DESCRIPTION
- support batch-wise evaluation for VSS by adding support of multiple queries in model.get_query_emb 
- enable batch-wise metric computation on the specified device (cuda/cpu) by adding parameter device and func evaluate_batch
- reduce the inference time by 100X