### PR TITLE
fix(STaRK-Amazon): Correct attribute access for product details

### DIFF
--- a/stark_qa/skb/amazon.py
+++ b/stark_qa/skb/amazon.py
@@ -253,7 +253,7 @@ class AmazonSKB(SKB):
         if hasattr(node, 'brand'):
             doc += f'- brand: {node.brand}\n'
         try:
-            dimensions, weight = node.details.dictionary.product_dimensions.split(' ; ')
+            dimensions, weight = node.details.product_dimensions.split(' ; ')
             doc += f'- dimensions: {dimensions}\n- weight: {weight}\n'
         except:
             pass


### PR DESCRIPTION
In [`stark_qa/skb/amazon.py`](diffhunk://#diff-6427aec040e628dcee8287a2a131fddc1913d0d7a027736cc913e69bd4218abdL256-R256),`get_doc_info` was not retrieving product dimensions and weight due to an error with `node.details.dictionary.product_dimensions`. This has been fixed by accessing `product_dimensions` directly from `node.details`.