### PR TITLE
Update pyproject.toml to support python 3.12

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,7 +30,7 @@ dependencies = [
     "transformers",
     "voyageai"
 ]
-requires-python = ">=3.8,<3.12"
+requires-python = ">=3.8"
 classifiers = [
     "Development Status :: 4 - Beta",
     "Intended Audience :: Developers",
@@ -40,6 +40,7 @@ classifiers = [
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12"
 ]
 authors = [
   { name="STaRK team", email="stark-qa@cs.stanford.edu" },


### PR DESCRIPTION
I've test this works with our [NVIDIA PyG containers](https://catalog.ngc.nvidia.com/orgs/nvidia/containers/pyg/tags)  for this [neo4j + PyG GNN+LLM example on stark-prime](https://github.com/neo4j-product-examples/neo4j-gnn-llm-example). Our PyTorch container (which is the base for our PyG one) has python 3.12 and this is a wide spread industry standard for many NVIDIA customers using PyTorch so having python 3.12 support is important.